### PR TITLE
Fixed Issue #6 README.txt file in plugin folder is not updated

### DIFF
--- a/root/README.txt
+++ b/root/README.txt
@@ -1,4 +1,4 @@
-=== @TODO: Plugin Name ===
+=== {%= title %} ===
 Contributors: (this should be a list of wordpress.org userids)
 Donate link: http://example.com/
 Tags: comments, spam
@@ -8,7 +8,7 @@ Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Here is a short description of the plugin.  This should be no more than 150 characters.  No markup here.
+{%= description %}
 
 == Description ==
 
@@ -46,7 +46,7 @@ e.g.
 = Using The WordPress Dashboard =
 
 1. Navigate to the 'Add New' in the plugins dashboard
-2. Search for 'plugin-name'
+2. Search for '{%= title %}'
 3. Click 'Install Now'
 4. Activate the plugin on the Plugin dashboard
 
@@ -54,15 +54,15 @@ e.g.
 
 1. Navigate to the 'Add New' in the plugins dashboard
 2. Navigate to the 'Upload' area
-3. Select `plugin-name.zip` from your computer
+3. Select `{%= slug %}.zip` from your computer
 4. Click 'Install Now'
 5. Activate the plugin in the Plugin dashboard
 
 = Using FTP =
 
-1. Download `plugin-name.zip`
-2. Extract the `plugin-name` directory to your computer
-3. Upload the `plugin-name` directory to the `/wp-content/plugins/` directory
+1. Download `{%= slug %}.zip`
+2. Extract the `{%= slug %}` directory to your computer
+3. Upload the `{%= slug %}` directory to the `/wp-content/plugins/` directory
 4. Activate the plugin in the Plugin dashboard
 
 


### PR DESCRIPTION
Addresses grunt init replacement tags not appearing in README.txt https://github.com/fooplugins/grunt-wp-boilerplate/issues/6
