### PR TITLE
Match wp boilerplate master - Support PHP 5.2.x by dropping dir __DIR__

### DIFF
--- a/root/admin/class-plugin-name-admin.php
+++ b/root/admin/class-plugin-name-admin.php
@@ -70,7 +70,7 @@ class {%= safe_name %}_Admin {
 		add_action( 'admin_menu', array( $this, 'add_plugin_admin_menu' ) );
 
 		// Add an action link pointing to the options page.
-		$plugin_basename = plugin_basename( plugin_dir_path( __DIR__ ) . $this->plugin_slug . '.php' );
+		$plugin_basename = plugin_basename( plugin_dir_path( realpath( dirname( __FILE__ ) ) ) . $this->plugin_slug . '.php' );
 		add_filter( 'plugin_action_links_' . $plugin_basename, array( $this, 'add_action_links' ) );
 
 		/*


### PR DESCRIPTION
 To keep in sync with WordPress-Plugin-Boilerplate update
